### PR TITLE
fix(metrics): restore deploy flow and add freshness monitoring

### DIFF
--- a/.github/workflows/monitor-usage-metrics-freshness.yml
+++ b/.github/workflows/monitor-usage-metrics-freshness.yml
@@ -1,0 +1,76 @@
+name: Monitor Usage Metrics Freshness
+
+on:
+  schedule:
+    - cron: "37 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check live metrics freshness
+        id: freshness
+        run: |
+          python scripts/check_usage_metrics_freshness.py \
+            --summary-url "https://liaohch3.com/data/ai-usage-summary.json" \
+            --threshold-hours 2 \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Create or update stale alert issue
+        if: steps.freshness.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Alert: usage metrics freshness stale"
+          issue_number="$(gh issue list --state open --json number,title --jq '.[] | select(.title == "'"${title}"'") | .number' | head -n 1)"
+          body="$(cat <<EOF
+          The live usage metrics summary looks stale.
+
+          - Summary URL: \`${{ steps.freshness.outputs.summary_url }}\`
+          - Checked at: \`${{ steps.freshness.outputs.checked_at }}\`
+          - Last updated at: \`${{ steps.freshness.outputs.updated_at }}\`
+          - Age: \`${{ steps.freshness.outputs.age_minutes }} minutes\`
+          - Threshold: \`${{ steps.freshness.outputs.threshold_minutes }} minutes\`
+          - Status: \`${{ steps.freshness.outputs.status }}\`
+          - Detail: \`${{ steps.freshness.outputs.detail }}\`
+
+          This alert is emitted by \`.github/workflows/monitor-usage-metrics-freshness.yml\`.
+          EOF
+          )"
+
+          if [ -n "${issue_number}" ]; then
+            gh issue comment "${issue_number}" --body "${body}"
+          else
+            gh issue create --title "${title}" --body "${body}"
+          fi
+
+      - name: Close stale alert issue after recovery
+        if: steps.freshness.outputs.stale != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Alert: usage metrics freshness stale"
+          issue_number="$(gh issue list --state open --json number,title --jq '.[] | select(.title == "'"${title}"'") | .number' | head -n 1)"
+          if [ -n "${issue_number}" ]; then
+            gh issue close "${issue_number}" --comment "Live usage metrics freshness recovered at \`${{ steps.freshness.outputs.checked_at }}\`. Latest summary timestamp: \`${{ steps.freshness.outputs.updated_at }}\`."
+          fi
+
+      - name: Fail when the live summary is stale
+        if: steps.freshness.outputs.stale == 'true'
+        run: |
+          echo "Usage metrics summary is stale."
+          echo "Detail: ${{ steps.freshness.outputs.detail }}"
+          exit 1

--- a/.github/workflows/refresh-usage-metrics.yml
+++ b/.github/workflows/refresh-usage-metrics.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
 
 jobs:
@@ -34,9 +35,11 @@ jobs:
         run: python scripts/export_usage_metrics.py
 
       - name: Commit refreshed data
+        id: commit_metrics
         run: |
           if git diff --quiet -- static/data/ai-usage-summary.json static/data/ai-usage-hourly.json static/data/ai-usage-daily.json static/data/ai-usage-insights.json; then
             echo "No metric changes"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git config user.name "github-actions[bot]"
@@ -44,3 +47,10 @@ jobs:
           git add static/data/ai-usage-summary.json static/data/ai-usage-hourly.json static/data/ai-usage-daily.json static/data/ai-usage-insights.json
           git commit -m "chore(data): refresh public usage metrics"
           git push
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Pages deploy
+        if: steps.commit_metrics.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api "repos/${{ github.repository }}/actions/workflows/gh-pages.yml/dispatches" -f ref="${{ github.ref_name }}"

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -268,10 +268,15 @@
 }
 
 .heat-cell {
+  appearance: none;
   width: 12px;
   height: 12px;
+  padding: 0;
+  border: none;
   border-radius: 3px;
   background: #ebedf0;
+  cursor: pointer;
+  transition: transform 0.16s ease, box-shadow 0.16s ease, opacity 0.16s ease;
 }
 
 .heat-l0 { background: #ebedf0; }
@@ -279,6 +284,16 @@
 .heat-l2 { background: #7bc96f; }
 .heat-l3 { background: #239a3b; }
 .heat-l4 { background: #196127; }
+
+.heat-cell:hover,
+.heat-cell:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 0 0 2px rgba(35, 154, 59, 0.18);
+}
+
+.heat-cell.is-active {
+  box-shadow: 0 0 0 2px rgba(35, 154, 59, 0.28);
+}
 
 .heatmap-legend {
   display: flex;
@@ -317,6 +332,16 @@
 
 .trend-dot {
   fill: #196127;
+  cursor: pointer;
+  transition: fill 0.16s ease, stroke-width 0.16s ease;
+}
+
+.trend-dot:hover,
+.trend-dot:focus-visible,
+.trend-dot.is-active {
+  fill: #239a3b;
+  stroke: rgba(25, 97, 39, 0.3);
+  stroke-width: 6;
 }
 
 .axis-row {
@@ -325,6 +350,17 @@
   gap: 10px;
   margin-top: 8px;
   text-transform: uppercase;
+}
+
+.axis-row span {
+  cursor: pointer;
+  transition: color 0.16s ease;
+}
+
+.axis-row span:hover,
+.axis-row span:focus-visible,
+.axis-row span.is-active {
+  color: var(--accent-color);
 }
 
 .model-bars,
@@ -340,6 +376,16 @@
   grid-template-columns: 92px 1fr auto;
   gap: 12px;
   align-items: center;
+  border-radius: 14px;
+  padding: 8px 10px;
+  transition: background 0.16s ease;
+}
+
+.model-bar-row:hover,
+.model-bar-row:focus-visible,
+.hour-bar-row:hover,
+.hour-bar-row:focus-visible {
+  background: color-mix(in srgb, var(--accent-color) 7%, var(--card-background));
 }
 
 .bar-track {
@@ -369,10 +415,104 @@
   text-transform: uppercase;
 }
 
+.metric-detail-panel {
+  position: relative;
+  overflow: hidden;
+}
+
+.detail-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.detail-stat,
+.detail-block {
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid var(--card-separator-color);
+  background: color-mix(in srgb, var(--accent-color) 6%, var(--card-background));
+}
+
+.detail-stat span {
+  display: block;
+  color: var(--card-text-color-tertiary);
+  font-family: var(--code-font-family);
+  font-size: 1.2rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.detail-stat strong {
+  display: block;
+  margin-top: 10px;
+  font-size: clamp(2rem, 2.8vw, 2.8rem);
+  line-height: 1.08;
+  color: var(--card-text-color-main);
+  overflow-wrap: anywhere;
+}
+
+.detail-stat em {
+  display: block;
+  margin-top: 10px;
+  font-style: normal;
+  color: var(--card-text-color-secondary);
+}
+
+.detail-chart-grid {
+  margin-top: 4px;
+}
+
+.detail-block {
+  display: grid;
+  gap: 12px;
+}
+
+.metric-tooltip {
+  position: fixed;
+  z-index: 999;
+  min-width: 220px;
+  max-width: 280px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(24, 21, 17, 0.94);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.24);
+  color: #fffdf7;
+  pointer-events: none;
+}
+
+.metric-tooltip-title {
+  font-family: var(--code-font-family);
+  font-size: 1.15rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.72);
+  margin-bottom: 8px;
+}
+
+.metric-tooltip-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 1.35rem;
+}
+
+.metric-tooltip-row + .metric-tooltip-row {
+  margin-top: 6px;
+}
+
+.metric-tooltip-row strong {
+  color: #fffdf7;
+  font-weight: 600;
+}
+
 @media (max-width: 1024px) {
   .metric-summary-grid,
   .metric-grid,
-  .metric-chart-grid {
+  .metric-chart-grid,
+  .detail-summary-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -252,7 +252,7 @@
 
 .heatmap-months {
   display: grid;
-  grid-template-columns: repeat(18, minmax(0, 1fr));
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 6px;
   text-transform: uppercase;
 }

--- a/content/metrics/index.md
+++ b/content/metrics/index.md
@@ -39,7 +39,7 @@ comments = false
         <div class="metric-overline">Token 墙</div>
         <h3>每天消耗多少 token，一眼看出来</h3>
       </div>
-      <div class="metric-caption">最近 18 周</div>
+      <div class="metric-caption">最近 30 天</div>
     </div>
     <div class="heatmap-shell">
       <div class="heatmap-weekdays">

--- a/content/metrics/index.md
+++ b/content/metrics/index.md
@@ -87,6 +87,28 @@ comments = false
     <p class="chart-copy">只是看看我平时大概在什么时段用得比较多。</p>
     <div class="hour-bars" id="usage-hour-bars"></div>
   </div>
+  <div class="metric-panel metric-detail-panel">
+    <div class="metric-head">
+      <div>
+        <div class="metric-overline">单日下钻</div>
+        <h3 id="usage-detail-title">点某一天看细节</h3>
+      </div>
+      <div class="metric-caption" id="usage-detail-caption">从上面的热力图或者折线里选一天</div>
+    </div>
+    <p class="chart-copy" id="usage-detail-copy">先看整体，再点某一天，下面会展开那天按小时和按模型的分布。</p>
+    <div class="detail-summary-grid" id="usage-detail-summary"></div>
+    <div class="metric-chart-grid detail-chart-grid">
+      <div class="detail-block">
+        <div class="metric-overline">按小时</div>
+        <div class="hour-bars" id="usage-day-hour-bars"></div>
+      </div>
+      <div class="detail-block">
+        <div class="metric-overline">按模型</div>
+        <div class="model-bars" id="usage-day-model-bars"></div>
+      </div>
+    </div>
+  </div>
+  <div class="metric-tooltip" id="usage-metric-tooltip" hidden></div>
 </div>
 
 <script>
@@ -95,6 +117,14 @@ comments = false
   const hourlyUrl = "/data/ai-usage-hourly.json";
   const dailyUrl = "/data/ai-usage-daily.json";
   const insightUrl = "/data/ai-usage-insights.json";
+  const state = {
+    summary: null,
+    hourlyRows: [],
+    dailyRows: [],
+    insights: null,
+    selectedDate: null,
+  };
+  const tooltip = document.getElementById("usage-metric-tooltip");
 
   const formatInt = (value) => new Intl.NumberFormat("en-US").format(Number(value || 0));
   const formatTime = (value) => {
@@ -102,6 +132,82 @@ comments = false
     const dt = new Date(value);
     if (Number.isNaN(dt.getTime())) return value;
     return `Updated ${dt.toLocaleString("zh-CN", { hour12: false })}`;
+  };
+  const formatDayLabel = (value) => {
+    const dt = new Date(`${value}T00:00:00Z`);
+    if (Number.isNaN(dt.getTime())) return value;
+    return dt.toLocaleDateString("zh-CN", {
+      month: "short",
+      day: "numeric",
+      weekday: "short",
+      timeZone: "UTC",
+    });
+  };
+  const escapeHtml = (value) =>
+    String(value ?? "").replace(/[&<>"']/g, (char) => ({
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    }[char]));
+  const sumBy = (rows, key) => rows.reduce((total, row) => total + Number(row[key] || 0), 0);
+  const tooltipMarkup = (title, rows) => `
+    <div class="metric-tooltip-title">${escapeHtml(title)}</div>
+    ${rows
+      .map(
+        ([label, value]) => `
+          <div class="metric-tooltip-row">
+            <span>${escapeHtml(label)}</span>
+            <strong>${escapeHtml(value)}</strong>
+          </div>
+        `
+      )
+      .join("")}
+  `;
+  const showTooltipAtPoint = (clientX, clientY, html) => {
+    if (!tooltip) return;
+    tooltip.hidden = false;
+    tooltip.innerHTML = html;
+
+    const padding = 14;
+    const { innerWidth, innerHeight } = window;
+    const rect = tooltip.getBoundingClientRect();
+    let left = clientX + padding;
+    let top = clientY + padding;
+
+    if (left + rect.width > innerWidth - 12) left = clientX - rect.width - padding;
+    if (top + rect.height > innerHeight - 12) top = clientY - rect.height - padding;
+
+    tooltip.style.left = `${Math.max(12, left)}px`;
+    tooltip.style.top = `${Math.max(12, top)}px`;
+  };
+  const showTooltipForEvent = (event, html) => showTooltipAtPoint(event.clientX, event.clientY, html);
+  const showTooltipForNode = (node, html) => {
+    const rect = node.getBoundingClientRect();
+    showTooltipAtPoint(rect.left + rect.width / 2, rect.top + rect.height / 2, html);
+  };
+  const hideTooltip = () => {
+    if (!tooltip) return;
+    tooltip.hidden = true;
+    tooltip.innerHTML = "";
+  };
+  const wireTooltip = (node, getHtml, onClick = null) => {
+    node.addEventListener("mouseenter", (event) => showTooltipForEvent(event, getHtml()));
+    node.addEventListener("mousemove", (event) => showTooltipForEvent(event, getHtml()));
+    node.addEventListener("mouseleave", hideTooltip);
+    node.addEventListener("focus", () => showTooltipForNode(node, getHtml()));
+    node.addEventListener("blur", hideTooltip);
+
+    if (onClick) {
+      node.addEventListener("click", () => onClick());
+      node.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onClick();
+        }
+      });
+    }
   };
 
   const setField = (name, value) => {
@@ -151,7 +257,7 @@ comments = false
     const maxTokens = Math.max(...rows.map((row) => Number(row.total_tokens || 0)), 1);
     let lastMonth = "";
 
-    rows.forEach((row, index) => {
+    rows.forEach((row) => {
       const date = new Date(`${row.date}T00:00:00Z`);
       if (date.getUTCDay() === 0) {
         const month = date.toLocaleDateString("en-US", { month: "short", timeZone: "UTC" });
@@ -168,9 +274,21 @@ comments = false
       if (value > maxTokens * 0.6) level = 3;
       if (value > maxTokens * 0.82) level = 4;
 
-      const cell = document.createElement("div");
-      cell.className = `heat-cell heat-l${level}`;
-      cell.title = `${row.date}: ${formatInt(value)} tokens`;
+      const cell = document.createElement("button");
+      cell.type = "button";
+      cell.className = `heat-cell heat-l${level}${row.date === state.selectedDate ? " is-active" : ""}`;
+      cell.setAttribute("aria-pressed", row.date === state.selectedDate ? "true" : "false");
+      cell.setAttribute("aria-label", `${formatDayLabel(row.date)} ${formatInt(value)} tokens`);
+      wireTooltip(
+        cell,
+        () =>
+          tooltipMarkup(formatDayLabel(row.date), [
+            ["Total", `${formatInt(value)} tokens`],
+            ["Status", value > 0 ? "Active day" : "No activity"],
+            ["Action", "Click to drill down"],
+          ]),
+        () => setSelectedDate(row.date)
+      );
       grid.appendChild(cell);
     });
   };
@@ -204,14 +322,62 @@ comments = false
     svg.innerHTML = `
       <path class="trend-area" d="${areaPath}"></path>
       <path class="trend-line" d="${linePath}"></path>
-      ${points.map((point) => `<circle class="trend-dot" cx="${point.x}" cy="${point.y}" r="4"></circle>`).join("")}
+      ${points
+        .map(
+          (point) => `
+            <circle
+              class="trend-dot${point.date === state.selectedDate ? " is-active" : ""}"
+              cx="${point.x}"
+              cy="${point.y}"
+              r="5"
+              tabindex="0"
+              role="button"
+              data-date="${point.date}"
+              data-total="${Number(point.total_tokens || 0)}"
+            ></circle>
+          `
+        )
+        .join("")}
     `;
+    svg.querySelectorAll(".trend-dot").forEach((dot) => {
+      const date = dot.getAttribute("data-date");
+      const totalTokens = Number(dot.getAttribute("data-total") || 0);
+      wireTooltip(
+        dot,
+        () =>
+          tooltipMarkup(formatDayLabel(date), [
+            ["Total", `${formatInt(totalTokens)} tokens`],
+            ["Action", "Click to drill down"],
+          ]),
+        () => setSelectedDate(date)
+      );
+    });
     axis.innerHTML = recent
-      .map((item) => `<span>${new Date(`${item.date}T00:00:00Z`).toLocaleDateString("en-US", { weekday: "short", timeZone: "UTC" })}</span>`)
+      .map(
+        (item) => `
+          <span
+            class="${item.date === state.selectedDate ? "is-active" : ""}"
+            tabindex="0"
+            role="button"
+            data-date="${item.date}"
+          >${new Date(`${item.date}T00:00:00Z`).toLocaleDateString("en-US", { weekday: "short", timeZone: "UTC" })}</span>
+        `
+      )
       .join("");
+    axis.querySelectorAll("span[data-date]").forEach((node) => {
+      const date = node.getAttribute("data-date");
+      wireTooltip(
+        node,
+        () =>
+          tooltipMarkup(formatDayLabel(date), [
+            ["Action", "Click to drill down"],
+          ]),
+        () => setSelectedDate(date)
+      );
+    });
   };
 
-  const renderBars = (containerId, rows, fillClass) => {
+  const renderBars = (containerId, rows, fillClass, options = {}) => {
     const container = document.getElementById(containerId);
     if (!container) return;
     container.innerHTML = "";
@@ -221,19 +387,197 @@ comments = false
     }
 
     const maxValue = Math.max(...rows.map((row) => Number(row.total_tokens || 0)), 1);
+    const getLabel = options.getLabel || ((row) => row.model || row.hour || "--");
+    const getValueText =
+      options.getValueText ||
+      ((row) => (row.share != null ? `${row.share}%` : formatInt(row.total_tokens)));
+    const getWidth =
+      options.getWidth ||
+      ((row) => (row.share != null ? Number(row.share) : (Number(row.total_tokens || 0) / maxValue) * 100));
+    const getTooltip = options.getTooltip || null;
+    const rowClass =
+      options.rowClass ||
+      (containerId.includes("hour-bars") ? "hour-bar-row" : "model-bar-row");
+
     rows.forEach((row) => {
       const item = document.createElement("div");
-      item.className = containerId === "usage-hour-bars" ? "hour-bar-row" : "model-bar-row";
-      const label = row.model || row.hour || "--";
-      const share = row.share != null ? `${row.share}%` : formatInt(row.total_tokens);
-      const width = row.share != null ? Number(row.share) : (Number(row.total_tokens || 0) / maxValue) * 100;
+      item.className = rowClass;
+      const label = getLabel(row);
+      const valueText = getValueText(row);
+      const width = getWidth(row);
       item.innerHTML = `
-        <div class="row-label">${label}</div>
+        <div class="row-label">${escapeHtml(label)}</div>
         <div class="bar-track"><div class="bar-fill ${fillClass}" style="width:${width}%"></div></div>
-        <div class="row-value">${share}</div>
+        <div class="row-value">${escapeHtml(valueText)}</div>
       `;
+      if (getTooltip) {
+        item.tabIndex = 0;
+        wireTooltip(item, () => getTooltip(row));
+      }
       container.appendChild(item);
     });
+  };
+
+  const buildDayDetail = (date) => {
+    const dailyRow = state.dailyRows.find((row) => row.date === date) || { date, total_tokens: 0 };
+    const dayRows = state.hourlyRows.filter((row) => String(row.hour || "").startsWith(date));
+    const hourBuckets = new Map();
+    const modelBuckets = new Map();
+
+    dayRows.forEach((row) => {
+      const hour = String(row.hour).slice(11, 16);
+      const hourBucket = hourBuckets.get(hour) || {
+        hour,
+        total_tokens: 0,
+        requests: 0,
+        success_requests: 0,
+        failed_requests: 0,
+      };
+      hourBucket.total_tokens += Number(row.total_tokens || 0);
+      hourBucket.requests += Number(row.requests || 0);
+      hourBucket.success_requests += Number(row.success_requests || 0);
+      hourBucket.failed_requests += Number(row.failed_requests || 0);
+      hourBuckets.set(hour, hourBucket);
+
+      const model = row.model || "unknown";
+      const modelBucket = modelBuckets.get(model) || {
+        model,
+        total_tokens: 0,
+        requests: 0,
+        success_requests: 0,
+        failed_requests: 0,
+      };
+      modelBucket.total_tokens += Number(row.total_tokens || 0);
+      modelBucket.requests += Number(row.requests || 0);
+      modelBucket.success_requests += Number(row.success_requests || 0);
+      modelBucket.failed_requests += Number(row.failed_requests || 0);
+      modelBuckets.set(model, modelBucket);
+    });
+
+    const hourRows = Array.from(hourBuckets.values()).sort((left, right) => left.hour.localeCompare(right.hour));
+    const modelRows = Array.from(modelBuckets.values()).sort((left, right) => right.total_tokens - left.total_tokens);
+    const busiestHour = hourRows.reduce(
+      (best, row) => (row.total_tokens > (best?.total_tokens || -1) ? row : best),
+      null
+    );
+    const topModel = modelRows[0] || null;
+
+    return {
+      date,
+      totalTokens: Number(dailyRow.total_tokens || sumBy(dayRows, "total_tokens")),
+      requests: sumBy(dayRows, "requests"),
+      successRequests: sumBy(dayRows, "success_requests"),
+      failedRequests: sumBy(dayRows, "failed_requests"),
+      activeHours: hourRows.length,
+      busiestHour,
+      topModel,
+      hourRows,
+      modelRows,
+    };
+  };
+
+  const renderDetailSummary = (detail) => {
+    const container = document.getElementById("usage-detail-summary");
+    if (!container) return;
+    if (!detail) {
+      container.innerHTML = '<div class="usage-empty">暂时还没有可下钻的数据。</div>';
+      return;
+    }
+
+    const stats = [
+      {
+        label: "当天 token",
+        value: formatInt(detail.totalTokens),
+        copy: detail.requests ? `${formatInt(detail.requests)} requests` : "当天还没有请求记录",
+      },
+      {
+        label: "活跃小时",
+        value: detail.activeHours ? String(detail.activeHours) : "--",
+        copy: detail.busiestHour
+          ? `${detail.busiestHour.hour} 最忙`
+          : "当天还没有小时级明细",
+      },
+      {
+        label: "请求状态",
+        value: detail.requests ? formatInt(detail.requests) : "--",
+        copy: detail.requests
+          ? `${formatInt(detail.successRequests)} ok · ${formatInt(detail.failedRequests)} failed`
+          : "当天还没有请求记录",
+      },
+      {
+        label: "最常用模型",
+        value: detail.topModel ? detail.topModel.model : "--",
+        copy: detail.topModel
+          ? `${formatInt(detail.topModel.total_tokens)} tokens`
+          : "当天还没有模型数据",
+      },
+    ];
+
+    container.innerHTML = stats
+      .map(
+        (stat) => `
+          <div class="detail-stat">
+            <span>${stat.label}</span>
+            <strong>${stat.value}</strong>
+            <em>${stat.copy}</em>
+          </div>
+        `
+      )
+      .join("");
+  };
+
+  const renderDetail = (date) => {
+    const title = document.getElementById("usage-detail-title");
+    const caption = document.getElementById("usage-detail-caption");
+    const copy = document.getElementById("usage-detail-copy");
+
+    if (!title || !caption || !copy) return;
+    if (!date) {
+      title.textContent = "点某一天看细节";
+      caption.textContent = "从上面的热力图或者折线里选一天";
+      copy.textContent = "先看整体，再点某一天，下面会展开那天按小时和按模型的分布。";
+      renderDetailSummary(null);
+      renderBars("usage-day-hour-bars", [], "hour-fill");
+      renderBars("usage-day-model-bars", [], "model-fill");
+      return;
+    }
+
+    const detail = buildDayDetail(date);
+    title.textContent = `${formatDayLabel(date)} 的明细`;
+    caption.textContent = detail.activeHours
+      ? `共 ${detail.activeHours} 个活跃小时`
+      : "当天还没有小时级明细";
+    copy.textContent = detail.activeHours
+      ? "上面的热力图和折线负责告诉你哪天最活跃，这里再展开看当天到底是哪些小时和哪些模型贡献了这些 token。"
+      : "这一天目前只有日级数据，还没有更细的小时分布可以展开。";
+
+    renderDetailSummary(detail);
+    renderBars("usage-day-hour-bars", detail.hourRows, "hour-fill", {
+      getValueText: (row) => `${formatInt(row.total_tokens)} tokens`,
+      getTooltip: (row) =>
+        tooltipMarkup(`${formatDayLabel(date)} ${row.hour}`, [
+          ["Total", `${formatInt(row.total_tokens)} tokens`],
+          ["Requests", formatInt(row.requests)],
+          ["Status", `${formatInt(row.success_requests)} ok · ${formatInt(row.failed_requests)} failed`],
+        ]),
+    });
+    renderBars("usage-day-model-bars", detail.modelRows, "model-fill", {
+      getValueText: (row) => `${formatInt(row.total_tokens)} tokens`,
+      getTooltip: (row) =>
+        tooltipMarkup(`${formatDayLabel(date)} ${row.model}`, [
+          ["Total", `${formatInt(row.total_tokens)} tokens`],
+          ["Requests", formatInt(row.requests)],
+          ["Status", `${formatInt(row.success_requests)} ok · ${formatInt(row.failed_requests)} failed`],
+        ]),
+    });
+  };
+
+  const setSelectedDate = (date) => {
+    if (!date || date === state.selectedDate) return;
+    state.selectedDate = date;
+    renderHeatmap(state.dailyRows);
+    renderTrend(state.dailyRows);
+    renderDetail(state.selectedDate);
   };
 
   Promise.all([requireJson(summaryUrl), requireJson(hourlyUrl), requireJson(dailyUrl), requireJson(insightUrl)])
@@ -242,6 +586,14 @@ comments = false
       const dailyRows = Array.isArray(daily.rows) ? daily.rows : [];
       const modelMix = Array.isArray(insights.model_mix) ? insights.model_mix : [];
       const hourMix = Array.isArray(insights.hour_mix) ? insights.hour_mix : [];
+      state.summary = summary;
+      state.hourlyRows = hourlyRows;
+      state.dailyRows = dailyRows;
+      state.insights = insights;
+      state.selectedDate =
+        [...dailyRows].reverse().find((row) => Number(row.total_tokens || 0) > 0)?.date ||
+        dailyRows.at(-1)?.date ||
+        null;
 
       setField("total_tokens", formatInt(summary.total_tokens));
       setField("token_breakdown", `Input ${formatInt(summary.input_tokens)} · Output ${formatInt(summary.output_tokens)}`);
@@ -257,8 +609,20 @@ comments = false
 
       renderHeatmap(dailyRows);
       renderTrend(dailyRows);
-      renderBars("usage-model-bars", modelMix, "model-fill");
-      renderBars("usage-hour-bars", hourMix, "hour-fill");
+      renderBars("usage-model-bars", modelMix, "model-fill", {
+        getTooltip: (row) =>
+          tooltipMarkup(row.model || "unknown", [
+            ["Total", `${formatInt(row.total_tokens)} tokens`],
+            ["Share", `${row.share}%`],
+          ]),
+      });
+      renderBars("usage-hour-bars", hourMix, "hour-fill", {
+        getTooltip: (row) =>
+          tooltipMarkup(row.hour || "--", [
+            ["Total", `${formatInt(row.total_tokens)} tokens`],
+          ]),
+      });
+      renderDetail(state.selectedDate);
     })
     .catch((error) => {
       setField("updated_at", "数据暂时不可用");
@@ -272,6 +636,7 @@ comments = false
       renderTrend([]);
       renderBars("usage-model-bars", [], "model-fill");
       renderBars("usage-hour-bars", [], "hour-fill");
+      renderDetail(null);
     });
 })();
 </script>

--- a/scripts/check_usage_metrics_freshness.py
+++ b/scripts/check_usage_metrics_freshness.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Check whether the live usage metrics summary has been refreshed recently."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+USER_AGENT = "liaohch3-usage-metrics-freshness-monitor/1.0"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check the freshness of the live usage metrics summary JSON."
+    )
+    parser.add_argument(
+        "--summary-url",
+        default="https://liaohch3.com/data/ai-usage-summary.json",
+        help="Live summary JSON URL to validate.",
+    )
+    parser.add_argument(
+        "--threshold-hours",
+        type=float,
+        default=2.0,
+        help="Maximum allowed age in hours before the summary is considered stale.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=15.0,
+        help="HTTP timeout for the summary fetch.",
+    )
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        default=None,
+        help="Optional path to append GitHub Actions step outputs.",
+    )
+    return parser.parse_args()
+
+
+def write_outputs(path: Path | None, values: dict[str, str]) -> None:
+    if path is None:
+        return
+
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            safe = str(value).replace("\r", " ").replace("\n", " ").strip()
+            handle.write(f"{key}={safe}\n")
+
+
+def parse_timestamp(raw: str) -> datetime:
+    value = raw.strip()
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value).astimezone(timezone.utc)
+
+
+def fetch_summary(url: str, timeout_seconds: float) -> dict:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+        },
+    )
+    with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+        return json.load(response)
+
+
+def main() -> int:
+    args = parse_args()
+    checked_at = datetime.now(tz=timezone.utc)
+    threshold_minutes = int(args.threshold_hours * 60)
+
+    outputs = {
+        "summary_url": args.summary_url,
+        "checked_at": checked_at.isoformat().replace("+00:00", "Z"),
+        "threshold_minutes": str(threshold_minutes),
+        "status": "unknown",
+        "stale": "true",
+        "updated_at": "unknown",
+        "age_minutes": "unknown",
+        "detail": "",
+    }
+
+    try:
+        payload = fetch_summary(args.summary_url, args.timeout_seconds)
+        raw_updated_at = payload.get("updated_at")
+        if not raw_updated_at:
+            raise ValueError("summary payload is missing updated_at")
+
+        updated_at = parse_timestamp(str(raw_updated_at))
+        age_seconds = max((checked_at - updated_at).total_seconds(), 0)
+        age_minutes = int(round(age_seconds / 60))
+        is_stale = age_seconds > args.threshold_hours * 3600
+
+        outputs.update(
+            {
+                "status": "stale" if is_stale else "fresh",
+                "stale": "true" if is_stale else "false",
+                "updated_at": updated_at.isoformat().replace("+00:00", "Z"),
+                "age_minutes": str(age_minutes),
+                "detail": (
+                    f"live summary age is {age_minutes} minutes"
+                    if not is_stale
+                    else f"live summary age is {age_minutes} minutes, above the {threshold_minutes}-minute threshold"
+                ),
+            }
+        )
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, ValueError, json.JSONDecodeError) as exc:
+        outputs.update(
+            {
+                "status": "error",
+                "stale": "true",
+                "detail": f"failed to fetch or parse the live summary: {exc}",
+            }
+        )
+
+    write_outputs(args.github_output, outputs)
+
+    print(
+        json.dumps(
+            {
+                "summary_url": outputs["summary_url"],
+                "checked_at": outputs["checked_at"],
+                "updated_at": outputs["updated_at"],
+                "age_minutes": outputs["age_minutes"],
+                "threshold_minutes": outputs["threshold_minutes"],
+                "status": outputs["status"],
+                "stale": outputs["stale"] == "true",
+                "detail": outputs["detail"],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_usage_metrics.py
+++ b/scripts/export_usage_metrics.py
@@ -12,7 +12,7 @@ PROJECT_ID = "liaohch3-trace-vault-260419"
 TABLE_ID = f"{PROJECT_ID}.usage_public.hourly_metrics_v1"
 ROOT = Path(__file__).resolve().parents[1]
 OUTPUT_DIR = ROOT / "static" / "data"
-HEATMAP_DAYS = 7 * 18
+HEATMAP_DAYS = 30
 ROW_KEYS = {
     "hour",
     "source",


### PR DESCRIPTION
## Summary
- dispatch `gh-pages.yml` after metrics refresh commits new data so refreshed JSON actually reaches the live site
- add a scheduled freshness monitor that checks the live summary JSON and opens or closes an alert issue when it goes stale for more than 2 hours
- upgrade the metrics page with hover tooltips and day-level drilldown from the heatmap and 7-day trend

## Validation
- `python3 -m py_compile scripts/check_usage_metrics_freshness.py`
- `python3 scripts/check_usage_metrics_freshness.py --summary-url https://liaohch3.com/data/ai-usage-summary.json --threshold-hours 2`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/refresh-usage-metrics.yml"); YAML.load_file(".github/workflows/monitor-usage-metrics-freshness.yml"); puts "YAML_OK"'`
- `node --check /tmp/metrics-page.js`
- `hugo --gc --minify`

## Notes
- the freshness monitor targets the live site JSON, not the repo copy, so it catches deploy regressions as well as data pipeline stalls
- the new chart interaction stays dependency-free and uses the existing static JSON payloads