### PR TITLE
fix(metrics): refine the public page styling

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -1042,35 +1042,66 @@
 }
 
 .public-metrics-refined {
-  gap: 20px;
+  gap: 18px;
+  margin-top: 0;
+}
+
+.main-article:has(.public-metrics-refined) > .article-header {
+  display: none;
+}
+
+.main-article:has(.public-metrics-refined) .article-content {
+  margin-top: 0;
+  margin-bottom: var(--card-padding);
+}
+
+.public-metrics-refined h2,
+.public-metrics-refined h3,
+.public-metrics-refined h4 {
+  margin-inline-start: 0;
+  padding-inline-start: 0;
+  border-inline-start: none;
 }
 
 .metric-hero-refined {
-  align-items: end;
-  gap: 20px;
-  margin-bottom: 2px;
+  align-items: start;
+  gap: 24px;
+  margin-bottom: 4px;
+  padding: 28px 28px 24px;
+  border-radius: 30px;
 }
 
 .metric-hero-refined .metric-hero-copy {
-  max-width: 780px;
+  max-width: 680px;
 }
 
 .metric-hero-refined h2 {
   margin: 0;
-  font-size: clamp(4.2rem, 7vw, 6.8rem);
-  line-height: 0.96;
+  font-size: clamp(3.8rem, 6vw, 5.6rem);
+  line-height: 0.98;
   letter-spacing: -0.06em;
+  max-width: 9ch;
 }
 
 .metric-hero-refined p {
-  max-width: 42ch;
+  max-width: 34ch;
   color: var(--card-text-color-secondary);
-  font-size: 1.72rem;
-  line-height: 1.8;
+  font-size: 1.62rem;
+  line-height: 1.72;
+}
+
+.metric-hero-refined .metric-updated {
+  display: grid;
+  gap: 6px;
+  justify-items: end;
+  min-width: 170px;
+  padding-left: 18px;
+  border-left: 1px solid color-mix(in srgb, var(--accent-color) 14%, var(--card-separator-color));
 }
 
 .metric-summary-grid-refined {
   grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
 }
 
 .metric-summary-grid-refined .metric-card,
@@ -1083,40 +1114,57 @@
 }
 
 .metric-summary-grid-refined .metric-card {
+  position: relative;
+  overflow: hidden;
   padding: 20px 22px;
-  border-radius: 26px;
+  border-radius: 24px;
+  min-height: 132px;
+  box-shadow: 0 18px 40px rgba(92, 74, 45, 0.05);
+}
+
+.metric-summary-grid-refined .metric-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto auto 0;
+  width: 100%;
+  height: 3px;
+  background: linear-gradient(90deg, #b78f58, #6dbb6c);
 }
 
 .metric-summary-grid-refined .metric-card strong {
-  font-size: clamp(2.6rem, 3vw, 3.5rem);
+  font-size: clamp(2.5rem, 2.7vw, 3.3rem);
 }
 
 .metric-summary-grid-refined .metric-card em {
   max-width: 28ch;
+  line-height: 1.6;
 }
 
 .metric-summary-grid-refined .metric-card-models strong {
-  font-size: clamp(2.3rem, 2.8vw, 3.2rem);
+  font-size: clamp(2.1rem, 2.5vw, 2.9rem);
   text-transform: none;
 }
 
 .activity-panel-refined {
-  padding: 26px;
+  padding: 24px;
+  border-radius: 30px;
+  box-shadow: 0 24px 48px rgba(92, 74, 45, 0.06);
 }
 
 .activity-panel-refined .metric-head h3 {
-  max-width: 8ch;
-  font-size: clamp(3.2rem, 5vw, 5rem);
+  max-width: none;
+  font-size: clamp(2.7rem, 3.6vw, 3.9rem);
+  line-height: 1.02;
 }
 
 .activity-panel-refined .metric-caption {
-  max-width: 20ch;
+  max-width: 18ch;
   text-align: right;
 }
 
 .activity-panel-refined .activity-layout {
   grid-template-columns: minmax(320px, 420px) minmax(0, 1fr);
-  gap: 24px;
+  gap: 20px;
 }
 
 .public-metrics-refined .activity-spotlight {
@@ -1148,7 +1196,7 @@
 }
 
 .activity-sequence-wrap {
-  padding: 20px 16px 18px;
+  padding: 18px 14px 16px;
   border-radius: 28px;
   border: 1px solid color-mix(in srgb, var(--accent-color) 8%, var(--card-separator-color));
   background: linear-gradient(180deg, rgba(247, 243, 236, 0.96), rgba(255, 255, 255, 0.98));
@@ -1180,13 +1228,16 @@
 
 .metric-secondary-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(300px, 1fr);
-  gap: 20px;
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.85fr);
+  gap: 16px;
   align-items: stretch;
 }
 
 .signal-panel {
   grid-row: span 2;
+  padding: 22px;
+  border-radius: 28px;
+  box-shadow: 0 20px 44px rgba(92, 74, 45, 0.05);
 }
 
 .signal-layout {
@@ -1199,8 +1250,8 @@
 .signal-block {
   display: grid;
   gap: 14px;
-  padding: 18px;
-  border-radius: 24px;
+  padding: 16px;
+  border-radius: 22px;
   border: 1px solid var(--card-separator-color);
   background: color-mix(in srgb, var(--accent-color) 4%, var(--card-background));
 }
@@ -1262,17 +1313,29 @@
   margin-bottom: 0;
 }
 
+.signal-panel h3 {
+  font-size: clamp(2.2rem, 2.5vw, 2.9rem);
+  line-height: 1.06;
+}
+
 .side-panel h3 {
-  font-size: clamp(2.8rem, 3.4vw, 4rem);
+  font-size: clamp(2.4rem, 2.8vw, 3.2rem);
+  line-height: 1.04;
 }
 
 .side-panel .rank-list,
 .side-panel .rhythm-chart {
-  margin-top: 18px;
+  margin-top: 16px;
 }
 
 .side-panel .rhythm-chart {
   min-height: 172px;
+}
+
+.side-panel {
+  padding: 20px 20px 18px;
+  border-radius: 26px;
+  box-shadow: 0 18px 40px rgba(92, 74, 45, 0.05);
 }
 
 .public-metrics-refined .model-chip-list {
@@ -1321,7 +1384,7 @@
 
 @media (max-width: 768px) {
   .metric-hero-refined h2 {
-    font-size: clamp(3.4rem, 12vw, 5.2rem);
+    font-size: clamp(3.2rem, 11vw, 4.6rem);
   }
 
   .metric-summary-grid-refined,
@@ -1332,6 +1395,13 @@
 
   .activity-panel-refined {
     padding: 20px;
+  }
+
+  .metric-hero-refined .metric-updated {
+    justify-items: start;
+    min-width: 0;
+    padding-left: 0;
+    border-left: none;
   }
 
   .activity-sequence-wrap {

--- a/content/metrics/index.md
+++ b/content/metrics/index.md
@@ -10,8 +10,8 @@ comments = false
   <div class="metric-hero metric-hero-refined">
     <div class="metric-hero-copy">
       <div class="metric-overline">AI 日常</div>
-      <h2>最近 30 天，我和 AI 一起写代码的公开节奏</h2>
-      <p>只看最近 30 天里哪天开工、强度多高、通常在哪个时段打开。</p>
+      <h2>最近 30 天的 AI 写码节奏</h2>
+      <p>只看哪天开工、强度多高、通常在哪个时段打开。</p>
     </div>
     <div class="metric-updated">
       <div data-usage-field="updated_at">--</div>
@@ -47,7 +47,7 @@ comments = false
     <div class="metric-head">
       <div>
         <div class="metric-overline">30 天节奏</div>
-        <h3>哪几天真的在写</h3>
+        <h3>最近哪几天在写</h3>
       </div>
       <div class="metric-caption" id="usage-activity-headline">hover 看当天卡片，click 锁定</div>
     </div>
@@ -66,7 +66,7 @@ comments = false
   <div class="metric-secondary-grid">
     <div class="metric-panel chart-panel signal-panel">
       <div class="metric-overline">总量信号</div>
-      <h3>输入输出和请求层表现</h3>
+      <h3>输入输出 / 请求层</h3>
       <div class="signal-layout">
         <div class="signal-block">
           <div class="signal-title">Token 结构</div>
@@ -82,12 +82,12 @@ comments = false
     </div>
     <div class="metric-panel chart-panel side-panel">
       <div class="metric-overline">模型</div>
-      <h3>最近主要开哪个模型</h3>
+      <h3>主力模型</h3>
       <div class="rank-list" id="usage-model-bars"></div>
     </div>
     <div class="metric-panel chart-panel side-panel">
       <div class="metric-overline">时段</div>
-      <h3>通常在什么时候打开</h3>
+      <h3>打开时段</h3>
       <div class="rhythm-chart" id="usage-hour-rhythm"></div>
       <div class="rhythm-axis">
         <span>00:00</span>


### PR DESCRIPTION
## Summary
- hide the duplicated theme article header on `/metrics/` and remove the theme heading border treatment from the custom metrics layout
- tighten the visual hierarchy with shorter Chinese titles, cleaner hero spacing, stronger metric cards, and calmer panel sizing
- keep the existing hover interaction and spotlight behavior while making the page read more like a single designed surface

## Validation
- `node --check /tmp/metrics_inline.js`
- `hugo --gc --minify`
- Playwright screenshot check against local build, including hover tooltip verification on `2026-04-19`
